### PR TITLE
Stop Vercel build crying for unused imports/vars

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -56,9 +56,9 @@ export default function Page() {
 
   // If the user is already signed in,
   // redirect them to the home page
-  //   if (isSignedIn) {
-  //     router.push("/");
-  //   }
+  if (isSignedIn) {
+    router.push("/");
+  }
 
   // Send the password reset code to the user's email
   async function create(e: React.FormEvent) {


### PR DESCRIPTION
stop vercel build cry because its so frigging strict when it comes to unused imports and vars